### PR TITLE
Fix beam code lines

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -10,3 +10,4 @@
 Thanks to Dave Cottlehuber @dch for testing.
 
 - freebsd tested and unsupported Logger error removed.
+- zig documentation is now correctly linked.

--- a/lib/zigler/doc/retriever.ex
+++ b/lib/zigler/doc/retriever.ex
@@ -25,7 +25,7 @@ defmodule Zigler.Doc.Retriever do
     end
 
     elixir_docs = ExDoc.Retriever.docs_from_dir(source_beam, config)
-    zig_docs = Enum.flat_map(source_dirs, &Zigler.Doc.Parser.docs_from_dir/1)
+    zig_docs = Enum.flat_map(source_dirs, &Zigler.Doc.Parser.docs_from_dir(&1, config))
 
     elixir_docs ++ zig_docs
   end


### PR DESCRIPTION
make zigdocs tag zig code with url links (at least, for github).