### PR TITLE
zig: use 0.7.0 ftw

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -62,3 +62,8 @@ Thanks to Dave Cottlehuber @dch for testing.
 
 - better support for nerves (thanks @fhunleth)
 - fixed documentation linking for bootstrap
+
+## 0.3.3
+
+- supported zig version: 0.7.0+d4c167f3c (2020-12-03)
+

--- a/lib/zigler/doc.ex
+++ b/lib/zigler/doc.ex
@@ -58,7 +58,7 @@ defmodule Zigler.Doc do
 
   ### Errors
 
-  errors appear inside special [error struct](https://ziglang.org/documentation/0.6.0/#Errors)
+  errors appear inside special [error struct](https://ziglang.org/documentation/0.7.0/#Errors)
   and should be documented at the per-value level:
 
   #### Example

--- a/lib/zigler/module.ex
+++ b/lib/zigler/module.ex
@@ -13,7 +13,7 @@ defmodule Zigler.Module do
     libs:         [],
     nifs:         [],
     resources:    [],
-    zig_version:  Version.parse!("0.6.0"),
+    zig_version:  Version.parse!("0.7.0+d4c167f3c"),
     imports:      @default_imports,
     c_includes:   [],
     include_dirs: [],


### PR DESCRIPTION
I've gotten a bit further with supporting zig 0.7.0, specifically https://ziglang.org/builds/zig-0.7.0+d4c167f3c.tar.xz which turned up today.

## changes

- used `Path.wildcard/1` as the `zig` executable jumps around between `./zig` and `./bin/zig` and back again
- removed a bunch of since-removed `zig build ...` options
- switched `--version-*`  and `--release-*`to their newer equivalents
- left a `Logger.debug/1` statement around because it was handy

## dirty stuff

I hacked in the download URL and version, maybe these could be configurable somehow, I'll add it if you think this is appropriate. I'd like to easily test newer zig versions simply by tweaking a config setting in the project's mix.exs, and not directly in zigler, for example.

```
Compiling 6 files (.ex)
warning: variable "download_location" is unused (if the variable is not meant to be used, prefix it with an underscore)
  lib/zigler/zig.ex:236: Zigler.Zig.fetch/1


22:32:43.463 [debug] copied /repos/zigler/test/support/zigtest/imported.zig to /tmp/.zigler_compiler/test/Elixir.ZiglerTest.ZigTest.Transitive/imported.zig

22:32:43.475 [debug] copied /repos/zigler/test/support/zigtest/namespaced.zig to /tmp/.zigler_compiler/test/Elixir.ZiglerTest.ZigTest.Transitive/namespaced.zig

22:32:43.475 [debug] copied /repos/zigler/test/support/zigtest/nonpublic.zig to /tmp/.zigler_compiler/test/Elixir.ZiglerTest.ZigTest.Transitive/nonpublic.zig

22:32:43.501 [debug] cannot truncate chardata because it contains something that is not valid chardata: {:cd, "/tmp/.zigler_compiler/test/Elixir.ZiglerTest.ZigTest.Transitive"}

22:32:43.501 [debug] cannot truncate chardata because it contains something that is not valid chardata: {:cd, "/tmp/.zigler_compiler/test/Elixir.ZiglerTest.ZigTest.FailingTest"}

22:32:43.501 [debug] cannot truncate chardata because it contains something that is not valid chardata: {:cd, "/tmp/.zigler_compiler/test/Elixir.ZiglerTest.ZigTest.PassingTests"}

22:32:48.449 [debug] loaded module at libElixir.ZiglerTest.ZigTest.Transitive

22:32:52.458 [debug] loaded module at libElixir.ZiglerTest.ZigTest.PassingTests

22:32:56.284 [debug] loaded module at libElixir.ZiglerTest.ZigTest.FailingTest

ZiglerTest.Integration.DocumentationTest
  * test documentation works (5.7ms)

ZiglerTest.Integration.CompileErrorTest
  * test zig compiler errors are bound to the correct line number (23254.7ms)
  * test zig compiler errors if there's no nif (15.9ms)
  * test zig compiler errors if there's no sigil z (14.4ms)

ZiglerTest.Integration.BeamTypeTest
  * test generic e_erl_nif_term (0.00ms)
  * test generic pid (4.9ms)
  * test generic erl_nif_pid (0.07ms)
  * test generic beam_term (0.00ms)

ZiglerTest.Imports.ImportTest
  * test importing inside the zig file is allowed (0.00ms)
  * test importing from subdirectories is allowed (0.00ms)
  * test re importing from subdirectories is allowed (0.00ms)

ZiglerTest.Integration.EnvTest
  * test for a zero arity function erlnifenv variables are valid first arguments (0.00ms)
  * test env variables are valid first arguments (0.00ms)
  * test erlnifenv variables are valid first arguments (0.00ms)
  * test for a zero arity function env variables are valid first arguments (0.00ms)

ZiglerTest.Include.ZiglerIncludeTest
  * test single include works from zigler preamble (0.00ms)

ZiglerTest.Imports.ZiglerImportTest
  * test imports can occur via the zigler settings (0.00ms)

ZiglerTest.Include.IncludeTest
  * test single include works (0.00ms)

ZiglerTest.Include.ZiglerMultiIncludeTest
  * test multiple include works from zigler preamble (0.00ms)

== Compilation error in file test/integration/resource_test.exs ==
** (CompileError) /tmp/.zigler_compiler/test/Elixir.ZiglerTest.Integration.ResourceTest/Elixir.ZiglerTest.Integration.ResourceTest.zig:226: duplicate switch value
    test_res_alt => return __test_res_alt_resource__,
    ^
./Elixir.ZiglerTest.Integration.ResourceTest.zig:24:57: note: called from here
  return beam.resource.fetch(i64, env, __resource_type__(test_res), value) catch 0;
                                                        ^
./Elixir.ZiglerTest.Integration.ResourceTest.zig:23:59: note: called from here
fn retrieve_resource(env: beam.env, value: beam.term) i64 {
                                                          ^
./Elixir.ZiglerTest.Integration.ResourceTest.zig:225:5: note: previous value is here
    test_res => return __test_res_resource__,
    ^
./Elixir.ZiglerTest.Integration.ResourceTest.zig:224:3: note: referenced here
  switch (T) {
  ^
./Elixir.ZiglerTest.Integration.ResourceTest.zig:226:5: error: duplicate switch value
    test_res_alt => return __test_res_alt_resource__,
    ^
./Elixir.ZiglerTest.Integration.ResourceTest.zig:234:58: note: called from here
    return beam.resource.create(T, env, __resource_type__(T), value);
                                                         ^
./Elixir.ZiglerTest.Integration.ResourceTest.zig:66:32: note: called from here
  var res = __resource__.create(test_pid_res, env, value)
                               ^
./Elixir.ZiglerTest.Integration.ResourceTest.zig:65:66: note: called from here
fn create_pid_resource(env: beam.env, value: beam.pid) beam.term {
                                                                 ^
./Elixir.ZiglerTest.Integration.ResourceTest.zig:225:5: note: previous value is here
    test_res => return __test_res_resource__,
    ^

    (zigler 0.3.2) lib/zigler/parser/error.ex:45: Zigler.Parser.Error.parse/2
    (zigler 0.3.2) lib/zigler/zig.ex:50: Zigler.Zig.compile/2
    (zigler 0.3.2) expanding macro: Zigler.Compiler.__before_compile__/1
    test/integration/resource_test.exs:1: ZiglerTest.Integration.ResourceTest (module)
    (elixir 1.10.4) lib/kernel/parallel_compiler.ex:396: Kernel.ParallelCompiler.require_file/2
    (elixir 1.10.4) lib/kernel/parallel_compiler.ex:306: anonymous fn/4 in Kernel.ParallelCompiler.spawn_workers/7
```

The remaining issues look like updates to zig itself, haven't looked closely at them yet.