### PR TITLE
fix: :bug: first steps to prepare zig to build on windows

### DIFF
--- a/lib/zig.ex
+++ b/lib/zig.ex
@@ -224,11 +224,6 @@ defmodule Zig do
   defmacro __using__(opts) do
     #mode = opts[:release_mode] || @default_release_mode
 
-    # make sure that we're in the correct operating system.
-    if match?({:win32, _}, :os.type()) do
-      raise "non-unix systems not currently supported."
-    end
-
     # clear out the assembly directory
     Mix.env
     |> Compiler.assembly_dir(__CALLER__.module)

--- a/lib/zig/compiler.ex
+++ b/lib/zig/compiler.ex
@@ -146,7 +146,9 @@ defmodule Zig.Compiler do
   ## STEPS
 
   def assembly_dir(env, module) do
-    Path.join(System.tmp_dir!(), ".zigler_compiler/#{env}/#{module}")
+    System.tmp_dir()
+    |> String.replace("\\", "/")
+    |> Path.join(".zigler_compiler/#{env}/#{module}")
   end
 
   @spec precompile(Zig.Module.t) :: t | no_return


### PR DESCRIPTION
fixed:
- add win{32,64} arch
- increased zig download tiimeout to 10 min
- path not being escaped
- use windows built-in `tar` instead of `unzip`