### PR TITLE
tests: use monotonic_time/1 to handle Time Warps correctly

### DIFF
--- a/test/integration/strategies/yielding_nif_test.exs
+++ b/test/integration/strategies/yielding_nif_test.exs
@@ -1,5 +1,4 @@
 defmodule ZiglerTest.Integration.Strategies.YieldingNifTest do
-
   # need to do this manually in order to prevent some strange library-on-load
   # segfault.
 
@@ -39,11 +38,20 @@ defmodule ZiglerTest.Integration.Strategies.YieldingNifTest do
   """
 
   test "yielding nifs can sleep for a while" do
-    start = DateTime.utc_now
+    # ideally, append `+C multi_time_warp` to `ERL_FLAGS`
+    # for more info, read:
+    # https://learnyousomeerlang.com/time
+    # https://erlang.org/doc/apps/erts/time_correction.html
+    # https://erlang.org/doc/man/erlang.html#type-time_unit
+    start = System.monotonic_time(:millisecond)
     assert 47 == yielding_forty_seven()
-    elapsed = DateTime.utc_now |> DateTime.diff(start)
-    assert elapsed >= 2
-    assert elapsed <= 4 # this one is a bit slower than I expected.
+    stop = System.monotonic_time(:millisecond)
+    # NB System.monotonic_time/1 may return negative values
+    # but they will always be monotonically increasing
+    elapsed = abs(start - stop)
+    assert elapsed >= 1000
+    # this one is a bit slower than I expected.
+    assert elapsed <= 4000
   end
 
   ~Z"""
@@ -92,7 +100,7 @@ defmodule ZiglerTest.Integration.Strategies.YieldingNifTest do
   """
 
   test "yielding nifs can have an slice input" do
-    assert 5050 == 1..100 |> Enum.to_list |> yielding_sum
+    assert 5050 == 1..100 |> Enum.to_list() |> yielding_sum
   end
 
   ~Z"""


### PR DESCRIPTION
Needs testing on other platforms to confirm.

TLDR: use monotonic time calculations everywhere. Remind people to append
`+C multi_time_warp` in `ERL_FLAGS` always.

By default, erts uses the pre-timewarp calculation of VM time, which is effectively
broken by design, and is still the default because changing the VM's handling of
time is a significant intrusion.

Elixir's `DateTime.utc_now/0` function calls on `System.os_time/0` which eventually
calls [system_time/0] which runs into the VM's fluid and confused notion of time
while running NIFs.
 

Ideally, you should always include `+C multi_time_warp` in `ERL_FLAGS`, anyway,
but by using `System.monotonic_time/1` we avoid the inherent problems in
`DateTime.utc_now/0` related to time warping.

For more info, read:
https://learnyousomeerlang.com/time
https://erlang.org/doc/apps/erts/time_correction.html
https://erlang.org/doc/man/erlang.html#type-time_unit

## test results on FreeBSD amd64 & aarch64, OTP 23.2.1, Elixir 1.10.4

```elixir
$ env ERL_AFLAGS='+C no_time_warp' mix test test/integration/strategies/yielding_nif_test.exs:41
Excluding tags: [:test]
Including tags: [line: "41"]
.
Finished in 10.6 seconds
7 tests, 0 failures, 6 excluded
Randomized with seed 679318

$ env ERL_AFLAGS='+C single_time_warp' mix test test/integration/strategies/yielding_nif_test.exs:41
Excluding tags: [:test]
Including tags: [line: "41"]
.
Finished in 11.1 seconds
7 tests, 0 failures, 6 excluded
Randomized with seed 673463

$ env ERL_AFLAGS='+C multi_time_warp' mix test test/integration/strategies/yielding_nif_test.exs:41
Excluding tags: [:test]
Including tags: [line: "41"]
.
Finished in 10.1 seconds
7 tests, 0 failures, 6 excluded
Randomized with seed 641953
```


[system_time/0]: http://erlang.org/doc/apps/erts/time_correction.html#os-system-time