### PR TITLE
Don't use Application.get_env/3 in module body

### DIFF
--- a/lib/zig/command.ex
+++ b/lib/zig/command.ex
@@ -63,7 +63,7 @@ defmodule Zig.Command do
     :ok
   end
 
-  @local_zig Application.get_env(:zigler, :local_zig, false)
+  @local_zig Application.compile_env(:zigler, :local_zig, false)
 
   defp executable_path(zig_tree), do: executable_path(zig_tree, @local_zig)
 

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule Zigler.MixProject do
     [
       app: :zigler,
       version: "0.9.2",
-      elixir: "~> 1.9",
+      elixir: "~> 1.10",
       start_permanent: env == :prod,
       elixirc_paths: elixirc_paths(env),
       deps: deps(),


### PR DESCRIPTION
By using application.compile_env we can guarantee that this module
gets recompiled when someone change zigler's config.

Bumps required elixir version to 1.10, since `Application.compile_env/3`.

Notice that Zigler **is already incompatible** with elixir 1.9 due to existing
`Application.compile_env/3` calls.