### PR TITLE
Fix linux CI by pinning ubuntu version

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -4,7 +4,7 @@ on: push
 
 jobs:
   ubuntu:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: Linux OTP ${{matrix.pair.otp-version}} / Elixir ${{matrix.pair.elixir-version}}
     strategy:
       matrix:


### PR DESCRIPTION
Hex doesn't build 23.0 for ubuntu-latest, which causes CI to fail. By pinning on 20.04 we can get CI to work. See
https://repo.hex.pm/builds/otp/ubuntu-20.04/builds.txt and
https://repo.hex.pm/builds/otp/ubuntu-22.04/builds.txt